### PR TITLE
feat: add markdown articles support with syntax highlighting

### DIFF
--- a/.github/scripts/build-articles.js
+++ b/.github/scripts/build-articles.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+
+const ARTICLES_DIR = path.join(process.cwd(), 'articles');
+const OUTPUT_FILE = path.join(ARTICLES_DIR, 'index.json');
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!match) return { data: {}, content };
+
+  const frontmatter = match[1];
+  const data = {};
+
+  frontmatter.split('\n').forEach(line => {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex > -1) {
+      const key = line.slice(0, colonIndex).trim();
+      const value = line.slice(colonIndex + 1).trim();
+      data[key] = value;
+    }
+  });
+
+  return { data, content: content.slice(match[0].length) };
+}
+
+function slugify(filename) {
+  return filename.replace(/\.md$/, '');
+}
+
+async function buildArticlesIndex() {
+  if (!fs.existsSync(ARTICLES_DIR)) {
+    console.log('No articles directory found, skipping...');
+    return;
+  }
+
+  const files = fs.readdirSync(ARTICLES_DIR)
+    .filter(f => f.endsWith('.md'))
+    .sort();
+
+  const articles = [];
+
+  for (const filename of files) {
+    const filepath = path.join(ARTICLES_DIR, filename);
+    const content = fs.readFileSync(filepath, 'utf8');
+    const { data } = parseFrontmatter(content);
+
+    if (!data.title) {
+      console.warn(`Warning: ${filename} has no title in frontmatter, skipping`);
+      continue;
+    }
+
+    articles.push({
+      slug: slugify(filename),
+      title: data.title,
+      description: data.description || '',
+      date: data.date || '',
+      filename
+    });
+  }
+
+  articles.sort((a, b) => {
+    if (!a.date) return 1;
+    if (!b.date) return -1;
+    return new Date(b.date) - new Date(a.date);
+  });
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(articles, null, 2) + '\n', 'utf8');
+  console.log(`✓ Built articles index: ${articles.length} article(s)`);
+  articles.forEach(a => console.log(`  - ${a.slug} (${a.date || 'no date'})`));
+}
+
+buildArticlesIndex().catch(err => {
+  console.error('Error building articles index:', err.message);
+  process.exit(1);
+});

--- a/.github/workflows/update-starred-repos.yml
+++ b/.github/workflows/update-starred-repos.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'  # Daily at midnight UTC
+  push:
+    paths:
+      - 'articles/**'
 
 permissions:
   contents: write
@@ -27,10 +30,14 @@ jobs:
         run: |
           node .github/scripts/update-starred-repos.js
 
+      - name: Build articles index
+        run: |
+          node .github/scripts/build-articles.js
+
       - name: Commit and push changes
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add index.html
-          git diff --staged --quiet || git commit -m "chore: update starred repos in projects section"
+          git add index.html articles/index.json
+          git diff --staged --quiet || git commit -m "chore: update starred repos and articles index"
           git push

--- a/articles/hello-world.md
+++ b/articles/hello-world.md
@@ -1,0 +1,39 @@
+---
+title: Hello World
+description: A first post introducing this articles section and what to expect here.
+date: 2025-11-10
+---
+
+# Hello World
+
+Welcome to the articles section of my site. This is where I plan to write about things I find interesting: reliability engineering, infrastructure automation, and the occasional side project deep-dive.
+
+## What to Expect
+
+Posts here will mostly cover topics I run into day-to-day as a Lead SRE:
+
+- Kubernetes operations and debugging
+- Infrastructure as code with Terraform
+- Automation with Ruby, Python, and JavaScript
+- Cloud platforms (AWS and GCP)
+- Incident response and postmortems
+
+## A Quick Code Example
+
+Here is a simple shell snippet I use to quickly check which pods are not in a `Running` state across all namespaces:
+
+```bash
+kubectl get pods --all-namespaces --field-selector=status.phase!=Running
+```
+
+And a Ruby one-liner to parse a log file and extract lines with errors:
+
+```ruby
+File.readlines('app.log').select { |l| l.match?(/ERROR|FATAL/) }.each { |l| puts l }
+```
+
+## Why Markdown?
+
+The articles on this site are plain Markdown files stored in the repository. No CMS, no database — just files and a small build step that generates an index. It keeps things simple and easy to version-control.
+
+That is about it for now. More posts coming soon.

--- a/articles/index.json
+++ b/articles/index.json
@@ -1,0 +1,16 @@
+[
+  {
+    "slug": "kubernetes-debugging-tips",
+    "title": "Kubernetes Debugging Tips for SREs",
+    "description": "Practical commands and patterns I reach for when something breaks in a Kubernetes cluster.",
+    "date": "2025-12-01",
+    "filename": "kubernetes-debugging-tips.md"
+  },
+  {
+    "slug": "hello-world",
+    "title": "Hello World",
+    "description": "A first post introducing this articles section and what to expect here.",
+    "date": "2025-11-10",
+    "filename": "hello-world.md"
+  }
+]

--- a/articles/kubernetes-debugging-tips.md
+++ b/articles/kubernetes-debugging-tips.md
@@ -1,0 +1,113 @@
+---
+title: Kubernetes Debugging Tips for SREs
+description: Practical commands and patterns I reach for when something breaks in a Kubernetes cluster.
+date: 2025-12-01
+---
+
+# Kubernetes Debugging Tips for SREs
+
+Kubernetes is great — until something goes wrong. Here are the commands and techniques I actually use when debugging production incidents.
+
+## Start with the Pod
+
+The first thing I do when alerted to an issue is check the pod state:
+
+```bash
+kubectl get pod <pod-name> -n <namespace> -o wide
+kubectl describe pod <pod-name> -n <namespace>
+```
+
+`describe` gives you events, resource limits, and the last container exit code. The exit code alone often tells you what happened:
+
+| Exit Code | Meaning |
+|-----------|---------|
+| 0 | Success |
+| 1 | General error |
+| 137 | OOM killed (128 + 9) |
+| 143 | Graceful termination (128 + 15) |
+
+## Logs
+
+Current logs:
+
+```bash
+kubectl logs <pod-name> -n <namespace>
+```
+
+Previous container instance (very useful after a crash loop):
+
+```bash
+kubectl logs <pod-name> -n <namespace> --previous
+```
+
+Follow logs in real time across multiple pods using a label selector:
+
+```bash
+kubectl logs -f -l app=my-service -n <namespace> --max-log-requests=10
+```
+
+## Exec into a Running Container
+
+Sometimes you need to poke around inside the container:
+
+```bash
+kubectl exec -it <pod-name> -n <namespace> -- /bin/sh
+```
+
+If `sh` is not available (distroless images), you can use an ephemeral debug container:
+
+```bash
+kubectl debug -it <pod-name> --image=busybox --target=<container-name> -n <namespace>
+```
+
+## Check Resource Pressure
+
+Node-level resource pressure can cause pods to be evicted or throttled:
+
+```bash
+kubectl top nodes
+kubectl top pods -n <namespace> --sort-by=memory
+```
+
+## Investigate a CrashLoopBackOff
+
+This is one of the most common states. The workflow:
+
+1. `kubectl describe pod` — look at the `Last State` exit code
+2. `kubectl logs --previous` — read the last crash output
+3. Check resource limits — the pod may be OOM-killed
+4. Check liveness probe configuration — a misconfigured probe causes restarts even when the app is healthy
+
+## Port Forward for Local Testing
+
+To hit a service locally without exposing it:
+
+```bash
+kubectl port-forward svc/my-service 8080:80 -n <namespace>
+```
+
+Then `curl localhost:8080` from your machine.
+
+## Useful One-Liners
+
+Get all pods not in Running state:
+
+```bash
+kubectl get pods -A --field-selector=status.phase!=Running
+```
+
+Restart a deployment:
+
+```bash
+kubectl rollout restart deployment/<name> -n <namespace>
+```
+
+Watch a rollout:
+
+```bash
+kubectl rollout status deployment/<name> -n <namespace> --watch
+```
+
+---
+
+These are the commands I find myself typing repeatedly during on-call. Bookmark them and you will save yourself a lot of time hunting through docs at 2am.

--- a/index.html
+++ b/index.html
@@ -105,43 +105,43 @@
                 <div class="project-item">
                     <h3>gemini-mac</h3>
                     <p>Native Google Gemini Mac App</p>
-                    <a href="https://github.com/allistera/gemini-mac" target="_blank">View on GitHub &rarr;</a>
+                    <a href="https://github.com/allistera/gemini-mac" target="_blank">View on GitHub →</a>
                 </div>
 
                 <div class="project-item">
                     <h3>email-viewer</h3>
                     <p>Custom Cloudflare Email Interface</p>
-                    <a href="https://github.com/allistera/email-viewer" target="_blank">View on GitHub &rarr;</a>
+                    <a href="https://github.com/allistera/email-viewer" target="_blank">View on GitHub →</a>
                 </div>
 
                 <div class="project-item">
                     <h3>Bookmark-AI</h3>
                     <p>Use AI to Automatically Sort Bookmarks</p>
-                    <a href="https://github.com/allistera/Bookmark-AI" target="_blank">View on GitHub &rarr;</a>
+                    <a href="https://github.com/allistera/Bookmark-AI" target="_blank">View on GitHub →</a>
                 </div>
 
                 <div class="project-item">
                     <h3>github-smash</h3>
                     <p>Deletes non-whitelisted Github Repos</p>
-                    <a href="https://github.com/allistera/github-smash" target="_blank">View on GitHub &rarr;</a>
+                    <a href="https://github.com/allistera/github-smash" target="_blank">View on GitHub →</a>
                 </div>
 
                 <div class="project-item">
                     <h3>cloudflare-neon-email</h3>
                     <p>Adds received email to a Neon Postgres Database before it forwards it on</p>
-                    <a href="https://github.com/allistera/cloudflare-neon-email" target="_blank">View on GitHub &rarr;</a>
+                    <a href="https://github.com/allistera/cloudflare-neon-email" target="_blank">View on GitHub →</a>
                 </div>
 
                 <div class="project-item">
                     <h3>allistera.github.io</h3>
                     <p>This homepage</p>
-                    <a href="https://github.com/allistera/allistera.github.io" target="_blank">View on GitHub &rarr;</a>
+                    <a href="https://github.com/allistera/allistera.github.io" target="_blank">View on GitHub →</a>
                 </div>
 
                 <div class="project-item">
                     <h3>infinitywave.design</h3>
                     <p>https://infinitywave.design/</p>
-                    <a href="https://github.com/allistera/infinitywave.design" target="_blank">View on GitHub &rarr;</a>
+                    <a href="https://github.com/allistera/infinitywave.design" target="_blank">View on GitHub →</a>
                 </div>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Allister Antosik - Lead SRE & Software Developer</title>
+    <title>Allister Antosik - Lead SRE &amp; Software Developer</title>
 
     <!-- SEO Meta Tags -->
     <meta name="description" content="Lead SRE with expertise in Ruby, JavaScript, Python, Terraform, AWS, GCP, and Kubernetes. Former Senior Software Developer building software and working on various projects.">
@@ -12,7 +12,7 @@
     <link rel="canonical" href="https://allisterantosik.com/">
 
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Allister Antosik - Lead SRE & Software Developer">
+    <meta property="og:title" content="Allister Antosik - Lead SRE &amp; Software Developer">
     <meta property="og:description" content="Lead SRE with expertise in Ruby, JavaScript, Python, Terraform, AWS, GCP, and Kubernetes. Former Senior Software Developer building software and working on various projects.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://allisterantosik.com/">
@@ -20,7 +20,7 @@
 
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="Allister Antosik - Lead SRE & Software Developer">
+    <meta name="twitter:title" content="Allister Antosik - Lead SRE &amp; Software Developer">
     <meta name="twitter:description" content="Lead SRE with expertise in Ruby, JavaScript, Python, Terraform, AWS, GCP, and Kubernetes. Former Senior Software Developer building software and working on various projects.">
 
     <!-- JSON-LD Structured Data -->
@@ -50,8 +50,22 @@
     </script>
 
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
 </head>
 <body>
+    <!-- Article view (shown when navigating to an article) -->
+    <div id="article-view" style="display: none;">
+        <div class="article-container">
+            <a href="#" class="back-link">&larr; Back</a>
+            <article>
+                <h1 id="article-title"></h1>
+                <p id="article-date" class="article-meta-date"></p>
+                <div id="article-content" class="article-content"></div>
+            </article>
+        </div>
+    </div>
+
+    <!-- Homepage -->
     <div class="container">
         <header>
             <h1>Allister Antosik</h1>
@@ -77,6 +91,13 @@
             </div>
         </section>
 
+        <section class="articles">
+            <h2>Articles</h2>
+            <div id="article-list" class="article-list">
+                <p class="articles-loading">Loading articles...</p>
+            </div>
+        </section>
+
         <section class="projects">
             <h2>Projects</h2>
             <p>Here are some recently worked on projects.</p>
@@ -84,43 +105,43 @@
                 <div class="project-item">
                     <h3>gemini-mac</h3>
                     <p>Native Google Gemini Mac App</p>
-                    <a href="https://github.com/allistera/gemini-mac" target="_blank">View on GitHub →</a>
+                    <a href="https://github.com/allistera/gemini-mac" target="_blank">View on GitHub &rarr;</a>
                 </div>
 
                 <div class="project-item">
                     <h3>email-viewer</h3>
                     <p>Custom Cloudflare Email Interface</p>
-                    <a href="https://github.com/allistera/email-viewer" target="_blank">View on GitHub →</a>
+                    <a href="https://github.com/allistera/email-viewer" target="_blank">View on GitHub &rarr;</a>
                 </div>
 
                 <div class="project-item">
                     <h3>Bookmark-AI</h3>
                     <p>Use AI to Automatically Sort Bookmarks</p>
-                    <a href="https://github.com/allistera/Bookmark-AI" target="_blank">View on GitHub →</a>
+                    <a href="https://github.com/allistera/Bookmark-AI" target="_blank">View on GitHub &rarr;</a>
                 </div>
 
                 <div class="project-item">
                     <h3>github-smash</h3>
                     <p>Deletes non-whitelisted Github Repos</p>
-                    <a href="https://github.com/allistera/github-smash" target="_blank">View on GitHub →</a>
+                    <a href="https://github.com/allistera/github-smash" target="_blank">View on GitHub &rarr;</a>
                 </div>
 
                 <div class="project-item">
                     <h3>cloudflare-neon-email</h3>
                     <p>Adds received email to a Neon Postgres Database before it forwards it on</p>
-                    <a href="https://github.com/allistera/cloudflare-neon-email" target="_blank">View on GitHub →</a>
+                    <a href="https://github.com/allistera/cloudflare-neon-email" target="_blank">View on GitHub &rarr;</a>
                 </div>
 
                 <div class="project-item">
                     <h3>allistera.github.io</h3>
                     <p>This homepage</p>
-                    <a href="https://github.com/allistera/allistera.github.io" target="_blank">View on GitHub →</a>
+                    <a href="https://github.com/allistera/allistera.github.io" target="_blank">View on GitHub &rarr;</a>
                 </div>
 
                 <div class="project-item">
                     <h3>infinitywave.design</h3>
                     <p>https://infinitywave.design/</p>
-                    <a href="https://github.com/allistera/infinitywave.design" target="_blank">View on GitHub →</a>
+                    <a href="https://github.com/allistera/infinitywave.design" target="_blank">View on GitHub &rarr;</a>
                 </div>
             </div>
         </section>
@@ -134,5 +155,141 @@
             <p class="copyright">&copy; 2025 Allister Antosik</p>
         </footer>
     </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script>
+      (function () {
+        'use strict';
+
+        function parseFrontmatter(content) {
+          var match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+          if (!match) return { data: {}, body: content };
+
+          var lines = match[1].split('\n');
+          var data = {};
+          lines.forEach(function (line) {
+            var idx = line.indexOf(':');
+            if (idx > -1) {
+              var key = line.slice(0, idx).trim();
+              var val = line.slice(idx + 1).trim();
+              data[key] = val;
+            }
+          });
+
+          return { data: data, body: content.slice(match[0].length) };
+        }
+
+        function escapeHtml(str) {
+          var div = document.createElement('div');
+          div.appendChild(document.createTextNode(str));
+          return div.innerHTML;
+        }
+
+        function formatDate(dateStr) {
+          var d = new Date(dateStr + 'T00:00:00');
+          return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+        }
+
+        function renderArticleCards(articles) {
+          var list = document.getElementById('article-list');
+
+          if (!articles.length) {
+            list.innerHTML = '<p class="articles-empty">No articles yet.</p>';
+            return;
+          }
+
+          list.innerHTML = articles.map(function (article) {
+            var dateHtml = article.date
+              ? '<p class="article-date">' + escapeHtml(formatDate(article.date)) + '</p>'
+              : '';
+            return '<div class="article-card" role="button" tabindex="0" data-slug="' + escapeHtml(article.slug) + '">'
+              + '<h3>' + escapeHtml(article.title) + '</h3>'
+              + dateHtml
+              + '<p class="article-description">' + escapeHtml(article.description) + '</p>'
+              + '<span class="article-link">Read more &rarr;</span>'
+              + '</div>';
+          }).join('');
+
+          list.querySelectorAll('.article-card').forEach(function (card) {
+            card.addEventListener('click', function () {
+              window.location.hash = 'article/' + card.getAttribute('data-slug');
+            });
+            card.addEventListener('keydown', function (e) {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                window.location.hash = 'article/' + card.getAttribute('data-slug');
+              }
+            });
+          });
+        }
+
+        async function loadArticleIndex() {
+          try {
+            var res = await fetch('articles/index.json');
+            if (!res.ok) return [];
+            return await res.json();
+          } catch (e) {
+            return [];
+          }
+        }
+
+        async function showArticle(slug) {
+          var homepage = document.querySelector('.container');
+          var view = document.getElementById('article-view');
+
+          try {
+            var res = await fetch('articles/' + slug + '.md');
+            if (!res.ok) throw new Error('Not found');
+            var text = await res.text();
+            var parsed = parseFrontmatter(text);
+
+            var html = window.marked.parse(parsed.body);
+
+            document.getElementById('article-title').textContent = parsed.data.title || slug;
+
+            var dateEl = document.getElementById('article-date');
+            dateEl.textContent = parsed.data.date ? formatDate(parsed.data.date) : '';
+
+            var contentEl = document.getElementById('article-content');
+            contentEl.innerHTML = html;
+
+            contentEl.querySelectorAll('pre code').forEach(function (block) {
+              window.hljs.highlightElement(block);
+            });
+
+            homepage.style.display = 'none';
+            view.style.display = '';
+            window.scrollTo(0, 0);
+          } catch (e) {
+            window.location.hash = '';
+          }
+        }
+
+        function showHomepage() {
+          document.querySelector('.container').style.display = '';
+          document.getElementById('article-view').style.display = 'none';
+        }
+
+        async function handleRouting() {
+          var hash = window.location.hash;
+          if (hash.indexOf('#article/') === 0) {
+            var slug = hash.slice('#article/'.length);
+            await showArticle(slug);
+          } else {
+            showHomepage();
+          }
+        }
+
+        async function init() {
+          var articles = await loadArticleIndex();
+          renderArticleCards(articles);
+          await handleRouting();
+        }
+
+        window.addEventListener('hashchange', handleRouting);
+        document.addEventListener('DOMContentLoaded', init);
+      }());
+    </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint:html": "htmlhint \"*.html\"",
     "lint:css": "stylelint \"**/*.css\"",
     "lint:js": "eslint \"**/*.js\"",
-    "lint:fix": "npm run lint:css -- --fix && npm run lint:js -- --fix"
+    "lint:fix": "npm run lint:css -- --fix && npm run lint:js -- --fix",
+    "build:articles": "node .github/scripts/build-articles.js"
   },
   "keywords": [
     "portfolio",

--- a/style.css
+++ b/style.css
@@ -172,6 +172,240 @@ footer {
     font-size: 1rem;
 }
 
+/* ── Article list (homepage) ───────────────────────────────────────────── */
+
+.article-list {
+    margin-top: 30px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.articles-loading,
+.articles-empty {
+    font-size: 1.1rem;
+    color: #6b7280;
+    margin-top: 10px;
+}
+
+.article-card {
+    padding: 25px;
+    background: #f9fafb;
+    border: 2px solid #e5e7eb;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.article-card:hover,
+.article-card:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgb(0 0 0 / 10%);
+    border-color: #9ca3af;
+    background: white;
+    outline: none;
+}
+
+.article-card h3 {
+    font-size: 1.4rem;
+    color: #232629;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.article-date {
+    font-size: 0.9rem;
+    color: #9ca3af;
+    margin-bottom: 10px;
+}
+
+.article-description {
+    color: #5d5d5d;
+    line-height: 1.6;
+    margin-bottom: 15px;
+}
+
+.article-link {
+    color: #4b5563;
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+/* ── Article view ──────────────────────────────────────────────────────── */
+
+#article-view {
+    background: #f8f9fa;
+    min-height: 100vh;
+}
+
+.article-container {
+    max-width: 750px;
+    margin: 0 auto;
+    padding: 40px 20px 80px;
+}
+
+.back-link {
+    display: inline-block;
+    color: #4b5563;
+    text-decoration: none;
+    font-weight: 600;
+    padding: 10px 0;
+    margin-bottom: 30px;
+    transition: color 0.2s;
+}
+
+.back-link:hover {
+    color: #1a1a1a;
+}
+
+.article-container article {
+    background: white;
+    padding: 50px 60px;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+    border: 1px solid #e5e7eb;
+}
+
+.article-container article h1 {
+    font-size: 2.5rem;
+    font-weight: 800;
+    color: #1a1a1a;
+    letter-spacing: -0.5px;
+    text-align: left;
+    margin-bottom: 10px;
+}
+
+.article-meta-date {
+    font-size: 0.95rem;
+    color: #9ca3af;
+    margin-bottom: 0;
+    padding-bottom: 30px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+/* ── Rendered markdown content ─────────────────────────────────────────── */
+
+.article-content h1,
+.article-content h2,
+.article-content h3,
+.article-content h4 {
+    color: #1a1a1a;
+    font-weight: 700;
+    margin-top: 2em;
+    margin-bottom: 0.75em;
+    line-height: 1.3;
+}
+
+.article-content h1 {
+    font-size: 2rem;
+}
+
+.article-content h2 {
+    display: block;
+    font-size: 1.6rem;
+    border-bottom: 2px solid #e5e7eb;
+    padding-bottom: 8px;
+}
+
+.article-content h3 {
+    font-size: 1.3rem;
+}
+
+.article-content p {
+    color: #374151;
+    font-size: 1.1rem;
+    line-height: 1.8;
+    margin-bottom: 1.5em;
+}
+
+.article-content a {
+    color: #2563eb;
+    text-decoration: underline;
+}
+
+.article-content a:hover {
+    color: #1d4ed8;
+}
+
+.article-content ul,
+.article-content ol {
+    padding-left: 2em;
+    margin-bottom: 1.5em;
+}
+
+.article-content li {
+    color: #374151;
+    font-size: 1.1rem;
+    line-height: 1.8;
+    margin-bottom: 0.25em;
+}
+
+.article-content blockquote {
+    border-left: 4px solid #e5e7eb;
+    padding-left: 1.5em;
+    margin: 1.5em 0;
+    color: #6b7280;
+    font-style: italic;
+}
+
+.article-content pre {
+    background: #f6f8fa;
+    border: 1px solid #e5e7eb;
+    border-radius: 4px;
+    padding: 20px;
+    overflow-x: auto;
+    margin-bottom: 1.5em;
+}
+
+.article-content code {
+    font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.9em;
+}
+
+.article-content pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.9rem;
+    color: inherit;
+}
+
+.article-content :not(pre) > code {
+    background: #f1f5f9;
+    padding: 0.2em 0.4em;
+    border-radius: 3px;
+    color: #c0392b;
+}
+
+.article-content hr {
+    border: none;
+    border-top: 2px solid #e5e7eb;
+    margin: 2em 0;
+}
+
+.article-content img {
+    max-width: 100%;
+    border-radius: 4px;
+}
+
+.article-content table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5em;
+    font-size: 1rem;
+}
+
+.article-content th,
+.article-content td {
+    border: 1px solid #e5e7eb;
+    padding: 10px 15px;
+    text-align: left;
+}
+
+.article-content th {
+    background: #f9fafb;
+    font-weight: 600;
+}
+
 @media (width <= 768px) {
     h1 {
         font-size: 2.5rem;
@@ -202,5 +436,13 @@ footer {
     .social-links a {
         width: 200px;
         text-align: center;
+    }
+
+    .article-container article {
+        padding: 30px 25px;
+    }
+
+    .article-container article h1 {
+        font-size: 1.8rem;
     }
 }


### PR DESCRIPTION
- Add articles/ directory for storing posts as Markdown files
- Frontmatter (title, description, date) drives homepage cards
- Client-side hash routing renders articles inline using marked.js
- Code blocks highlighted via highlight.js (GitHub theme)
- Build script (.github/scripts/build-articles.js) generates articles/index.json
- Workflow now triggers on push to articles/** and runs the build script
- Add build:articles npm script for local use

https://claude.ai/code/session_01RDCeSzVcJ9cC3gbDQBNPXL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new client-side routing/rendering that fetches and injects Markdown/HTML at runtime and introduces external CDN dependencies; also updates CI to auto-generate/commit derived content on pushes to `articles/**`.
> 
> **Overview**
> Adds a new Markdown-based *Articles* section: posts live under `articles/` with simple frontmatter, are listed on the homepage via `articles/index.json`, and can be opened via hash routing to a dedicated article view rendered client-side with `marked` + `highlight.js`.
> 
> Introduces `.github/scripts/build-articles.js` (also exposed as `npm run build:articles`) to generate/sort `articles/index.json`, and updates the `update-starred-repos` GitHub Action to run this build, trigger on `articles/**` pushes, and commit `articles/index.json` alongside `index.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c69a3a484c3011c30adf76f08771e1c205cee4a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->