### PR TITLE
feat: add markdown article support with syntax highlighting

### DIFF
--- a/.github/scripts/update-articles.js
+++ b/.github/scripts/update-articles.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+
+const ARTICLES_DIR = path.join(process.cwd(), 'articles');
+const INDEX_PATH = path.join(ARTICLES_DIR, 'index.json');
+
+function parseFrontMatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!match) return {};
+
+  const frontMatter = {};
+  match[1].split('\n').forEach(line => {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx > 0) {
+      const key = line.substring(0, colonIdx).trim();
+      const value = line.substring(colonIdx + 1).trim();
+      frontMatter[key] = value;
+    }
+  });
+  return frontMatter;
+}
+
+function generateArticlesIndex() {
+  const files = fs.readdirSync(ARTICLES_DIR)
+    .filter(f => f.endsWith('.md'))
+    .sort();
+
+  const articles = files.map(filename => {
+    const slug = filename.replace(/\.md$/, '');
+    const filePath = path.join(ARTICLES_DIR, filename);
+    const content = fs.readFileSync(filePath, 'utf8');
+    const frontMatter = parseFrontMatter(content);
+
+    return {
+      slug,
+      title: frontMatter.title || slug,
+      description: frontMatter.description || '',
+      date: frontMatter.date || ''
+    };
+  });
+
+  articles.sort((a, b) => {
+    if (!a.date) return 1;
+    if (!b.date) return -1;
+    return new Date(b.date) - new Date(a.date);
+  });
+
+  fs.writeFileSync(INDEX_PATH, JSON.stringify(articles, null, 2) + '\n', 'utf8');
+  console.log(`Generated articles/index.json with ${articles.length} article(s)`);
+}
+
+function main() {
+  try {
+    if (!fs.existsSync(ARTICLES_DIR)) {
+      console.log('No articles directory found, skipping');
+      return;
+    }
+    generateArticlesIndex();
+    console.log('✓ Articles index updated successfully');
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/.github/workflows/update-starred-repos.yml
+++ b/.github/workflows/update-starred-repos.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'  # Daily at midnight UTC
+  push:
+    branches:
+      - main
+    paths:
+      - 'articles/**'
 
 permissions:
   contents: write
@@ -27,10 +32,14 @@ jobs:
         run: |
           node .github/scripts/update-starred-repos.js
 
+      - name: Generate articles index
+        run: |
+          node .github/scripts/update-articles.js
+
       - name: Commit and push changes
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add index.html
-          git diff --staged --quiet || git commit -m "chore: update starred repos in projects section"
+          git add index.html articles/index.json
+          git diff --staged --quiet || git commit -m "chore: update starred repos and articles index"
           git push

--- a/articles/index.json
+++ b/articles/index.json
@@ -1,0 +1,8 @@
+[
+  {
+    "slug": "zero-downtime-kubernetes-deployments",
+    "title": "Zero-Downtime Deployments with Kubernetes Rolling Updates",
+    "description": "Learn how to configure Kubernetes rolling updates and readiness probes to keep your applications available during every deployment.",
+    "date": "2025-11-15"
+  }
+]

--- a/articles/zero-downtime-kubernetes-deployments.md
+++ b/articles/zero-downtime-kubernetes-deployments.md
@@ -1,0 +1,168 @@
+---
+title: Zero-Downtime Deployments with Kubernetes Rolling Updates
+description: Learn how to configure Kubernetes rolling updates and readiness probes to keep your applications available during every deployment.
+date: 2025-11-15
+---
+
+# Zero-Downtime Deployments with Kubernetes Rolling Updates
+
+Deploying new versions of an application without dropping traffic is one of the core responsibilities of an SRE. Kubernetes rolling updates make this achievable out of the box, but a few misconfigurations can still cause brief outages. This guide walks through the key settings and why they matter.
+
+## How Rolling Updates Work
+
+When you update a Deployment, Kubernetes gradually replaces old Pods with new ones. At no point does it terminate all running Pods first — instead it respects two key parameters:
+
+- **`maxSurge`** — how many extra Pods can be created above the desired replica count during the update
+- **`maxUnavailable`** — how many Pods can be unavailable at any given time during the update
+
+By default both values are set to `25%`, which means for a 4-replica Deployment, Kubernetes will bring up one new Pod before terminating an old one.
+
+## Basic Deployment Configuration
+
+Here is a minimal Deployment that demonstrates the key fields:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-api
+  namespace: production
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: my-api
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: my-api
+    spec:
+      containers:
+        - name: my-api
+          image: ghcr.io/allistera/my-api:1.2.0
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+```
+
+Setting `maxUnavailable: 0` guarantees that the service always has the full replica count available. The trade-off is that the rollout takes slightly longer because a new Pod must become ready before an old one is terminated.
+
+## Why Readiness Probes Are Non-Negotiable
+
+Without a readiness probe Kubernetes has no way to know that your new container is actually serving traffic. It will mark the Pod as `Ready` the moment the container starts, and the old Pod is terminated immediately — before your application has finished booting.
+
+A minimal HTTP readiness probe looks like this in practice:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /healthz
+  port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 3
+```
+
+Your `/healthz` endpoint should return a non-2xx status code if the application is not ready to serve traffic (for example, while a database migration is still running).
+
+## Triggering and Watching a Rollout
+
+Once your Deployment is configured, triggering an update is as simple as changing the image tag:
+
+```bash
+kubectl set image deployment/my-api \
+  my-api=ghcr.io/allistera/my-api:1.3.0 \
+  -n production
+```
+
+You can watch the progress in real time:
+
+```bash
+kubectl rollout status deployment/my-api -n production
+```
+
+If something looks wrong, roll back immediately:
+
+```bash
+kubectl rollout undo deployment/my-api -n production
+```
+
+Kubernetes keeps the previous ReplicaSet around (controlled by `revisionHistoryLimit`), so the rollback is instant — no image pull required.
+
+## Pod Disruption Budgets
+
+For critical services, pair your rolling update strategy with a `PodDisruptionBudget`. This protects your Pods from being evicted simultaneously during a node drain or cluster upgrade:
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: my-api-pdb
+  namespace: production
+spec:
+  minAvailable: 3
+  selector:
+    matchLabels:
+      app: my-api
+```
+
+This ensures at least 3 out of 4 replicas are always available, even if a node is taken offline for maintenance.
+
+## Graceful Shutdown
+
+The final piece of the puzzle is making sure your application handles `SIGTERM` correctly. When Kubernetes terminates a Pod it sends `SIGTERM` and then waits for `terminationGracePeriodSeconds` (default 30s) before force-killing with `SIGKILL`.
+
+A Node.js application that drains in-flight requests before exiting:
+
+```javascript
+process.on('SIGTERM', () => {
+  console.log('Received SIGTERM, shutting down gracefully');
+
+  server.close(() => {
+    console.log('All connections closed, exiting');
+    process.exit(0);
+  });
+
+  // Force exit if graceful shutdown takes too long
+  setTimeout(() => {
+    console.error('Graceful shutdown timed out, forcing exit');
+    process.exit(1);
+  }, 25000);
+});
+```
+
+Set `terminationGracePeriodSeconds` on the Pod spec to match the maximum time your application needs to drain:
+
+```yaml
+spec:
+  terminationGracePeriodSeconds: 30
+```
+
+## Summary
+
+Achieving zero-downtime deployments with Kubernetes requires four things working together:
+
+1. **Rolling update strategy** — `maxUnavailable: 0` with `maxSurge: 1` keeps the full replica count available at all times
+2. **Readiness probes** — prevent traffic from reaching Pods that are not yet ready
+3. **Pod Disruption Budgets** — protect against simultaneous evictions during cluster operations
+4. **Graceful shutdown** — drain in-flight requests before the process exits
+
+Get these right and your deployments become a non-event for your users.

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
     </script>
 
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
 </head>
 <body>
     <div class="container">
@@ -76,6 +77,19 @@
                 <span class="skill-pill">Kubernetes</span>
             </div>
         </section>
+
+        <section class="articles" id="articles-section">
+            <h2>Articles</h2>
+            <p>Thoughts and guides on SRE, infrastructure, and software development.</p>
+            <div class="article-list" id="article-list">
+                <p class="articles-loading">Loading articles...</p>
+            </div>
+        </section>
+
+        <div class="article-view" id="article-view" style="display: none;">
+            <a href="#" class="back-link">&#8592; Back</a>
+            <article id="article-content" class="article-content"></article>
+        </div>
 
         <section class="projects">
             <h2>Projects</h2>
@@ -134,5 +148,109 @@
             <p class="copyright">&copy; 2025 Allister Antosik</p>
         </footer>
     </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.3.0/marked.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script>
+    (function () {
+        marked.use({
+            renderer: {
+                code: function (code, lang) {
+                    if (lang && hljs.getLanguage(lang)) {
+                        var highlighted = hljs.highlight(code, { language: lang }).value;
+                        return '<pre><code class="hljs language-' + lang + '">' + highlighted + '</code></pre>';
+                    }
+                    var highlighted = hljs.highlightAuto(code).value;
+                    return '<pre><code class="hljs">' + highlighted + '</code></pre>';
+                }
+            }
+        });
+
+        function parseFrontMatter(text) {
+            var match = text.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+            if (!match) return { frontMatter: {}, content: text };
+            var frontMatter = {};
+            match[1].split('\n').forEach(function (line) {
+                var colonIdx = line.indexOf(':');
+                if (colonIdx > 0) {
+                    frontMatter[line.substring(0, colonIdx).trim()] = line.substring(colonIdx + 1).trim();
+                }
+            });
+            return { frontMatter: frontMatter, content: match[2] };
+        }
+
+        function escapeHtml(text) {
+            return String(text)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;');
+        }
+
+        function homeSections() {
+            return document.querySelectorAll('.about, .skills, .projects, #articles-section');
+        }
+
+        function showHome() {
+            homeSections().forEach(function (el) { el.style.display = ''; });
+            document.getElementById('article-view').style.display = 'none';
+            loadArticleList();
+        }
+
+        function loadArticleList() {
+            var list = document.getElementById('article-list');
+            fetch('articles/index.json')
+                .then(function (res) { return res.json(); })
+                .then(function (articles) {
+                    if (!articles.length) {
+                        list.innerHTML = '<p>No articles yet.</p>';
+                        return;
+                    }
+                    list.innerHTML = articles.map(function (article) {
+                        return '<a class="article-card" href="#article=' + escapeHtml(article.slug) + '">' +
+                            '<h3>' + escapeHtml(article.title) + '</h3>' +
+                            '<p class="article-desc">' + escapeHtml(article.description) + '</p>' +
+                            '<span class="article-date">' + escapeHtml(article.date) + '</span>' +
+                            '</a>';
+                    }).join('');
+                })
+                .catch(function () {
+                    list.innerHTML = '<p>Could not load articles.</p>';
+                });
+        }
+
+        function showArticle(slug) {
+            if (!/^[a-z0-9-]+$/.test(slug)) return showHome();
+            homeSections().forEach(function (el) { el.style.display = 'none'; });
+            var articleView = document.getElementById('article-view');
+            articleView.style.display = '';
+            var content = document.getElementById('article-content');
+            content.innerHTML = '<p>Loading...</p>';
+            fetch('articles/' + slug + '.md')
+                .then(function (res) {
+                    if (!res.ok) throw new Error('Not found');
+                    return res.text();
+                })
+                .then(function (text) {
+                    var parsed = parseFrontMatter(text);
+                    content.innerHTML = marked.parse(parsed.content);
+                })
+                .catch(function () {
+                    content.innerHTML = '<p>Article not found.</p>';
+                });
+        }
+
+        function handleRoute() {
+            var match = window.location.hash.match(/^#article=([a-z0-9-]+)$/);
+            if (match) {
+                showArticle(match[1]);
+            } else {
+                showHome();
+            }
+        }
+
+        window.addEventListener('hashchange', handleRoute);
+        window.addEventListener('load', handleRoute);
+    }());
+    </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -124,6 +124,181 @@ h2 {
     line-height: 1.6;
 }
 
+/* Articles section */
+.articles > p {
+    font-size: 1.2rem;
+    color: #4d4d4d;
+    line-height: 1.8;
+    margin-top: 20px;
+}
+
+.article-list {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-top: 30px;
+}
+
+.article-card {
+    display: block;
+    padding: 25px;
+    background: #f9fafb;
+    border: 2px solid #e5e7eb;
+    border-radius: 4px;
+    text-decoration: none;
+    color: inherit;
+    transition: all 0.3s ease;
+}
+
+.article-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgb(0 0 0 / 10%);
+    border-color: #9ca3af;
+    background: white;
+}
+
+.article-card h3 {
+    font-size: 1.4rem;
+    color: #1a1a1a;
+    font-weight: 600;
+    margin-bottom: 10px;
+}
+
+.article-card .article-desc {
+    color: #5d5d5d;
+    line-height: 1.6;
+    margin-bottom: 10px;
+}
+
+.article-card .article-date {
+    font-size: 0.9rem;
+    color: #6b7280;
+}
+
+.articles-loading {
+    color: #6b7280;
+    font-style: italic;
+}
+
+/* Article view */
+.article-view {
+    background: white;
+    padding: 50px 40px;
+    margin-bottom: 40px;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+    border: 1px solid #e5e7eb;
+}
+
+.back-link {
+    display: inline-block;
+    color: #4b5563;
+    text-decoration: none;
+    font-weight: 600;
+    margin-bottom: 30px;
+    transition: color 0.2s;
+}
+
+.back-link:hover {
+    color: #1a1a1a;
+}
+
+/* Rendered article content */
+.article-content h1 {
+    font-size: 2.5rem;
+    font-weight: 800;
+    margin-bottom: 15px;
+    color: #1a1a1a;
+    letter-spacing: -0.5px;
+    border-bottom: 3px solid #d1d5db;
+    padding-bottom: 15px;
+    display: block;
+}
+
+.article-content h2 {
+    font-size: 1.8rem;
+    margin-top: 40px;
+    margin-bottom: 15px;
+    font-weight: 700;
+    border-bottom: 2px solid #e5e7eb;
+    padding-bottom: 8px;
+    display: block;
+}
+
+.article-content h3 {
+    font-size: 1.3rem;
+    margin-top: 30px;
+    margin-bottom: 10px;
+    font-weight: 600;
+    color: #1a1a1a;
+}
+
+.article-content p {
+    font-size: 1.1rem;
+    color: #374151;
+    line-height: 1.8;
+    margin-bottom: 20px;
+}
+
+.article-content ul,
+.article-content ol {
+    margin-left: 25px;
+    margin-bottom: 20px;
+    color: #374151;
+    font-size: 1.1rem;
+    line-height: 1.8;
+}
+
+.article-content li {
+    margin-bottom: 8px;
+}
+
+.article-content code {
+    background: #f3f4f6;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.9em;
+    color: #374151;
+}
+
+.article-content pre {
+    margin-bottom: 25px;
+    border-radius: 6px;
+    overflow-x: auto;
+    border: 1px solid #e5e7eb;
+}
+
+.article-content pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: inherit;
+}
+
+.article-content blockquote {
+    border-left: 4px solid #d1d5db;
+    padding-left: 20px;
+    margin: 20px 0;
+    color: #6b7280;
+    font-style: italic;
+}
+
+.article-content a {
+    color: #4b5563;
+    text-decoration: underline;
+}
+
+.article-content a:hover {
+    color: #1a1a1a;
+}
+
+.article-content strong {
+    font-weight: 700;
+    color: #1a1a1a;
+}
+
 footer {
     text-align: center;
     padding: 50px 0 30px;
@@ -202,5 +377,17 @@ footer {
     .social-links a {
         width: 200px;
         text-align: center;
+    }
+
+    .article-view {
+        padding: 30px 25px;
+    }
+
+    .article-content h1 {
+        font-size: 2rem;
+    }
+
+    .article-content h2 {
+        font-size: 1.5rem;
     }
 }


### PR DESCRIPTION
- Articles are stored in articles/ as markdown files with YAML front matter (title, description, date)
- Homepage shows an Articles section with clickable cards; clicking loads the rendered article via hash routing (#article=<slug>)
- marked.js renders markdown and highlight.js provides code syntax highlighting with the GitHub theme
- articles/index.json lists all articles and is regenerated automatically by the new .github/scripts/update-articles.js script
- GitHub workflow now triggers on pushes to articles/** and regenerates the articles index as part of the existing update job
- Adds one example article: Zero-Downtime Deployments with Kubernetes

https://claude.ai/code/session_01DscG5CFX2ki2LCz4USosQq